### PR TITLE
Mantis: 1272726 -> Removed packages default version

### DIFF
--- a/file-content-extraction/connector.py
+++ b/file-content-extraction/connector.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 

--- a/file-content-extraction/info.json
+++ b/file-content-extraction/info.json
@@ -1,7 +1,7 @@
 {
   "name": "file-content-extraction",
   "label": "File Content Extraction",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Utility to Extract Text, Artifacts and Metadata from almost any file. Internet connectivity is required for the connector to download dependent packages",
   "publisher": "Fortinet",
   "supportInfo": "https://github.com/ftnt-cse",
@@ -10,7 +10,7 @@
   "category": "Utilities",
   "icon_small_name": "small_icon.png",
   "icon_large_name": "large_icon.png",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.3.1/file-content-extraction/131/file-content-extraction-v1-3-1",
+  "help_online": "",
   "configuration": {
   },
   "operations": [

--- a/file-content-extraction/operations.py
+++ b/file-content-extraction/operations.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 

--- a/file-content-extraction/playbooks/playbooks.json
+++ b/file-content-extraction/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - File Content Extraction - 1.3.1",
+      "name": "Sample - File Content Extraction - 1.4.0",
       "description": "Sample playbooks for \"File Content Extraction\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "image": "/api/3/images/ffea24b7-a875-4f05-b321-b22cfe396856",
@@ -83,7 +83,7 @@
                 "params": {
                   "verbose_config": true
                 },
-                "version": "1.3.1",
+                "version": "1.4.0",
                 "connector": "file-content-extraction",
                 "operation": "get_backend_config",
                 "operationTitle": "Get Backend Config",
@@ -161,7 +161,7 @@
                   "file_iri": "{{vars.input.records[0].file['@id']}}",
                   "html_output_format": false
                 },
-                "version": "1.3.1",
+                "version": "1.4.0",
                 "connector": "file-content-extraction",
                 "operation": "extract_text",
                 "operationTitle": "Extract Text",
@@ -329,7 +329,7 @@
                 "name": "File Content Extraction",
                 "config": "''",
                 "params": [],
-                "version": "1.3.1",
+                "version": "1.4.0",
                 "connector": "file-content-extraction",
                 "operation": "extract_indicators_from_file",
                 "operationTitle": "Extract Artifacts Extended"
@@ -409,7 +409,7 @@
                   "jsonData": null,
                   "xLSXFields": ""
                 },
-                "version": "1.3.1",
+                "version": "1.4.0",
                 "connector": "file-content-extraction",
                 "operation": "create_xslx_file_from_json_data",
                 "operationTitle": "Create XSLX file as attachment from JSON Data"

--- a/file-content-extraction/release_notes.md
+++ b/file-content-extraction/release_notes.md
@@ -1,2 +1,4 @@
 #### What's Fixed
-- Security Fixes 
+
+- Removed the specific version constraints for packages from requirements.txt, as the pinned version is causing
+  dependency conflicts in the Integrations Service environment and leading to service startup failures.

--- a/file-content-extraction/requirements.txt
+++ b/file-content-extraction/requirements.txt
@@ -1,4 +1,4 @@
-tika>=1.24
+tika
 ioc-finder
-pandas>=2.0.2
-XlsxWriter>=3.1.9
+pandas
+XlsxWriter

--- a/file-content-extraction/tests/__init__.py
+++ b/file-content-extraction/tests/__init__.py
@@ -1,6 +1,6 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """

--- a/file-content-extraction/tests/test_operations.py
+++ b/file-content-extraction/tests/test_operations.py
@@ -6,7 +6,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 


### PR DESCRIPTION
#### Mantis: 1272726

#### Description:

- Removed the specific version constraints for packages from requirements.txt, as the pinned version is causing
  dependency conflicts in the Integrations Service environment and leading to service startup failures.